### PR TITLE
adds `classof` to AST components

### DIFF
--- a/include/schreiber/info.hpp
+++ b/include/schreiber/info.hpp
@@ -59,12 +59,25 @@ namespace info {
 
 		friend auto operator==(decl_info const&, decl_info const&) -> bool = default;
 	protected:
+		enum class kind {
+			parameter_info,
+			template_parameter_info,
+			function_info,
+		};
+
 		decl_info(
+		  kind kind,
 		  clang::Decl const* decl,
 		  std::string description,
 		  std::vector<header_info> headers = {},
 		  std::vector<module_info> modules = {}) noexcept;
+
+		[[nodiscard]] static auto get_kind(decl_info const& decl) noexcept -> kind
+		{
+			return decl.kind_;
+		}
 	private:
+		kind kind_;
 		clang::Decl const* decl_;
 		std::string description_;
 		std::vector<header_info> headers_;
@@ -84,6 +97,9 @@ namespace info {
 
 		friend auto
 		operator==(template_parameter_info const&, template_parameter_info const&) -> bool = default;
+
+		/// Determines whether a ``decl_info const*`` points to a ``parameter_info`` object.
+		static auto classof(decl_info const* decl) -> bool;
 	private:
 		bool show_default_;
 	};
@@ -98,6 +114,9 @@ namespace info {
 		parameter_info(clang::ParmVarDecl const* decl, std::string description) noexcept;
 
 		friend auto operator==(parameter_info const&, parameter_info const&) -> bool = default;
+
+		/// Determines whether a ``decl_info const*`` points to a ``parameter_info`` object.
+		static auto classof(decl_info const* decl) -> bool;
 	private:
 		bool show_default_;
 	};
@@ -204,6 +223,9 @@ namespace info {
 		[[nodiscard]] auto exits_via() const noexcept -> std::span<exits_via_info const>;
 
 		friend auto operator==(function_info const&, function_info const&) -> bool = default;
+
+		/// Determines whether a ``decl_info const*`` points to a ``function_info`` object.
+		static auto classof(decl_info const* decl) -> bool;
 	private:
 		std::vector<template_parameter_info> template_parameters_;
 		std::vector<parameter_info> parameters_;

--- a/source/info.cpp
+++ b/source/info.cpp
@@ -14,11 +14,13 @@
 
 namespace info {
 	decl_info::decl_info(
+	  kind kind,
 	  clang::Decl const* decl,
 	  std::string description,
 	  std::vector<header_info> headers,
 	  std::vector<module_info> modules) noexcept
-	: decl_(decl)
+	: kind_(kind)
+	, decl_((CJDB_ASSERT(decl != nullptr), decl))
 	, description_(std::move(description))
 	, headers_(std::move(headers))
 	, modules_(std::move(modules))
@@ -55,7 +57,7 @@ namespace info {
 	  std::vector<exits_via_info> exits_via,
 	  std::vector<header_info> headers,
 	  std::vector<module_info> modules) noexcept
-	: decl_info(decl, std::move(description), std::move(headers), std::move(modules))
+	: decl_info(kind::function_info, decl, std::move(description), std::move(headers), std::move(modules))
 	, parameters_((CJDB_EXPECTS(parameters.size() <= decl->param_size()), std::move(parameters)))
 	, returns_(std::move(returns))
 	, preconditions_(std::move(preconditions))
@@ -77,7 +79,7 @@ namespace info {
 	  std::vector<exits_via_info> exits_via,
 	  std::vector<header_info> headers,
 	  std::vector<module_info> modules) noexcept
-	: decl_info(decl, std::move(description), std::move(headers), std::move(modules))
+	: decl_info(kind::function_info, decl, std::move(description), std::move(headers), std::move(modules))
 	, template_parameters_(std::move(template_parameters))
 	, parameters_(std::move(parameters))
 	, exception_specifier_(std::move(exception_specifier))
@@ -128,25 +130,40 @@ namespace info {
 		return exits_via_;
 	}
 
+	auto function_info::classof(decl_info const* const decl) -> bool
+	{
+		return get_kind(*decl) == kind::function_info;
+	}
+
 	parameter_info::parameter_info(clang::ParmVarDecl const* decl, std::string description) noexcept
-	: decl_info(decl, std::move(description))
+	: decl_info(kind::parameter_info, decl, std::move(description))
 	{}
+
+	auto parameter_info::classof(decl_info const* const decl) -> bool
+	{
+		return get_kind(*decl) == kind::parameter_info;
+	}
 
 	template_parameter_info::template_parameter_info(
 	  clang::TemplateTypeParmDecl const* decl,
 	  std::string description)
-	: decl_info(decl, std::move(description))
+	: decl_info(kind::template_parameter_info, decl, std::move(description))
 	{}
 
 	template_parameter_info::template_parameter_info(
 	  clang::NonTypeTemplateParmDecl const* decl,
 	  std::string description)
-	: decl_info(decl, std::move(description))
+	: decl_info(kind::template_parameter_info, decl, std::move(description))
 	{}
 
 	template_parameter_info::template_parameter_info(
 	  clang::TemplateTemplateParmDecl const* decl,
 	  std::string description)
-	: decl_info(decl, std::move(description))
+	: decl_info(kind::template_parameter_info, decl, std::move(description))
 	{}
+
+	auto template_parameter_info::classof(decl_info const* const decl) -> bool
+	{
+		return get_kind(*decl) == kind::template_parameter_info;
+	}
 } // namespace info

--- a/test/info/CMakeLists.txt
+++ b/test/info/CMakeLists.txt
@@ -1,4 +1,10 @@
 cxx_test(
+  TARGET test_classof.cpp
+  FILENAME test_classof
+  LINK_TARGETS info
+)
+
+cxx_test(
   TARGET test_function_info
   FILENAME test_function_info.cpp
   LINK_TARGETS info

--- a/test/info/test_classof.cpp
+++ b/test/info/test_classof.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) Google LLC.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#include <catch2/catch_test_macros.hpp>
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclTemplate.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/Tooling/Tooling.h>
+#include <llvm/Support/Casting.h>
+#include <schreiber/info.hpp>
+
+namespace {
+	namespace tooling = clang::tooling;
+
+	using clang::ast_matchers::functionTemplateDecl;
+	using clang::ast_matchers::match;
+
+	TEST_CASE("classof works correctly")
+	{
+		SECTION("function-based code")
+		{
+			constexpr auto code = R"(
+template<class T>
+void f(T t);
+)";
+			auto ast = tooling::buildASTFromCodeWithArgs(code, {"-target", "x86_64-unknown-linux-gnu"});
+			auto& context = ast->getASTContext();
+			auto const decl = selectFirst<clang::FunctionTemplateDecl>(
+			  "decl",
+			  match(functionTemplateDecl().bind("decl"), context));
+			REQUIRE(decl != nullptr);
+			REQUIRE(decl->getAsFunction()->param_size() == 1);
+
+			SECTION("function_info")
+			{
+				auto f = info::function_info(decl, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {});
+				CHECK(info::function_info::classof(static_cast<info::decl_info const*>(&f)));
+				CHECK_FALSE(info::parameter_info::classof(static_cast<info::decl_info const*>(&f)));
+				CHECK_FALSE(info::template_parameter_info::classof(static_cast<info::decl_info const*>(&f)));
+			}
+
+			SECTION("parameter_info")
+			{
+				auto const param = decl->getAsFunction()->getParamDecl(0);
+				auto p = info::parameter_info(param, {});
+				CHECK_FALSE(info::function_info::classof(static_cast<info::decl_info const*>(&p)));
+				CHECK(info::parameter_info::classof(static_cast<info::decl_info const*>(&p)));
+				CHECK_FALSE(info::template_parameter_info::classof(static_cast<info::decl_info const*>(&p)));
+			}
+
+			SECTION("template_parameter_info")
+			{
+				auto const template_param_list = decl->getTemplateParameters();
+				REQUIRE(template_param_list->size() == 1);
+				auto t = info::template_parameter_info(
+				  llvm::dyn_cast<clang::TemplateTypeParmDecl>(template_param_list->getParam(0)),
+				  {});
+				CHECK_FALSE(info::function_info::classof(static_cast<info::decl_info const*>(&t)));
+				CHECK_FALSE(info::parameter_info::classof(static_cast<info::decl_info const*>(&t)));
+				CHECK(info::template_parameter_info::classof(static_cast<info::decl_info const*>(&t)));
+			}
+		}
+	}
+} // namespace


### PR DESCRIPTION
Since we're not using RTTI for this project, we need to leverage LLVM's alternative to `dynamic_cast`. This is achieved by getting the class to identify itself to `llvm::dyn_cast`, which then performs a conversion on our behalf.