### PR TITLE
installs TableGen and uses it to generate diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ if(${PROJECT_NAME}_ENABLE_CLANG_TIDY)
 endif()
 
 include_directories(include)
+include_directories("${CMAKE_BINARY_DIR}/third_party/llvm/")
 include_directories(SYSTEM "${CLANG_INCLUDE_DIRS}")
+
+include(AddLLVM)
+include(AddClang)
+
+add_subdirectory(third_party)
 add_subdirectory(source)
 add_subdirectory(test)

--- a/config/cmake/FindClangTableGen.cmake
+++ b/config/cmake/FindClangTableGen.cmake
@@ -1,0 +1,7 @@
+include(FindPackageHandleStandardArgs)
+
+if(EXISTS "${CLANG_TABLEGEN}")
+  set(ClangTableGen_FOUND On)
+endif()
+
+find_package_handle_standard_args(ClangTableGen REQUIRED_VARS ClangTableGen_FOUND)

--- a/config/cmake/FindLLVMTableGen.cmake
+++ b/config/cmake/FindLLVMTableGen.cmake
@@ -1,0 +1,7 @@
+include(FindPackageHandleStandardArgs)
+
+if(EXISTS "${LLVM_TABLEGEN}")
+  set(LLVMTableGen_FOUND On)
+endif()
+
+find_package_handle_standard_args(LLVMTableGen REQUIRED_VARS LLVMTableGen_FOUND)

--- a/include/schreiber/diagnostic_ids.hpp
+++ b/include/schreiber/diagnostic_ids.hpp
@@ -1,0 +1,36 @@
+// Copyright (c) Google LLC.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#ifndef SCHREIBER_DIAGNOSTIC_IDS_HPP
+#define SCHREIBER_DIAGNOSTIC_IDS_HPP
+
+#include <clang/Basic/Diagnostic.h>
+#include <clang/Basic/DiagnosticIDs.h>
+
+namespace diag {
+	enum class size {
+		lex = 0,
+	};
+
+	enum start {
+		DIAG_START_LEX = clang::diag::DIAG_UPPER_LIMIT - 1, // NOLINT(readability-identifier-naming)
+	};
+
+	// clang-format off
+	enum id {
+#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
+             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
+  ENUM,
+#define LEXSTART
+#include "diagnostics/DiagnosticLexKinds.inc"
+		num_schreiber_lex_diagnostics,
+	};
+#undef DIAG
+
+	// clang-format on
+
+	/// Adds all the Schreiber diagnostics to the diagnostics engine.
+	void add_diagnostics(clang::DiagnosticsEngine& engine);
+} // namespace diag
+
+#endif // SCHREIBER_DIAGNOSTIC_IDS_HPP

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,3 @@
-include(AddLLVM)
-include(AddClang)
-
 cxx_library(
   TARGET info
   FILENAME info.cpp
@@ -11,3 +8,11 @@ cxx_library(
     clangFrontend
     clangTooling
 )
+
+cxx_library(
+  TARGET diagnostic_ids
+  FILENAME diagnostic_ids.cpp
+  LINK_AND_EXPORT_TARGETS
+    clangBasic
+)
+add_dependencies(diagnostic_ids schreiber-tablegen-targets)

--- a/source/diagnostic_ids.cpp
+++ b/source/diagnostic_ids.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) Google LLC.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#include <clang/Basic/Diagnostic.h>
+#include <schreiber/diagnostic_ids.hpp>
+
+namespace diag {
+	using clang::diag::Severity; // NOLINT(misc-include-cleaner)
+
+	void add_diagnostics(clang::DiagnosticsEngine& engine)
+	{
+		// clang-format off
+#define DIAG(ENUM, FLAGS, SEVERITY, DESC, GROUP, SFINAE, NOWERROR,                              \
+             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)                             \
+		engine.getCustomDiagID(static_cast<clang::DiagnosticsEngine::Level>(SEVERITY), DESC);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#include "diagnostics/DiagnosticLexKinds.inc" // NOLINT(misc-include-cleaner)
+#pragma GCC diagnostic pop
+#undef DIAG
+		// clang-format on
+	}
+} // namespace diag

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,4 +3,5 @@
 #
 set(${PROJECT_NAME}_TEST_FRAMEWORK "Catch2::Catch2" "Catch2::Catch2WithMain" CACHE STRING "")
 
+add_subdirectory(diagnostics)
 add_subdirectory(info)

--- a/test/diagnostics/CMakeLists.txt
+++ b/test/diagnostics/CMakeLists.txt
@@ -1,0 +1,8 @@
+cxx_test(
+  TARGET check_diagnostic_ids
+  FILENAME check_diagnostic_ids.cpp
+  LINK_TARGETS
+    clangAST
+    clangTooling
+    diagnostic_ids
+)

--- a/test/diagnostics/check_diagnostic_ids.cpp
+++ b/test/diagnostics/check_diagnostic_ids.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) Google LLC.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+#include <catch2/catch_test_macros.hpp>
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclCXX.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/Basic/Diagnostic.h>
+#include <clang/Frontend/ASTUnit.h>
+#include <clang/Frontend/TextDiagnosticPrinter.h>
+#include <clang/Tooling/Tooling.h>
+#include <llvm/Support/raw_ostream.h>
+#include <schreiber/diagnostic_ids.hpp>
+#include <string>
+
+namespace {
+	namespace ast_matchers = clang::ast_matchers;
+	namespace tooling = clang::tooling;
+
+	using ast_matchers::functionDecl;
+	using ast_matchers::match;
+	using ast_matchers::selectFirst;
+
+	TEST_CASE("errors can be emitted")
+	{
+		auto text = std::string();
+		auto stream = llvm::raw_string_ostream(text);
+
+		auto ast = tooling::buildASTFromCode("int f();");
+		auto& context = ast->getASTContext();
+		auto& engine = context.getDiagnostics();
+		engine.setClient(new clang::TextDiagnosticPrinter(stream, &engine.getDiagnosticOptions(), false));
+		diag::add_diagnostics(engine);
+
+		auto const* decl =
+		  selectFirst<clang::FunctionDecl>("decl", match(functionDecl().bind("decl"), context));
+
+		REQUIRE(decl != nullptr);
+		REQUIRE(engine.getNumErrors() == 0);
+		REQUIRE(engine.getNumWarnings() == 0);
+
+		SECTION("reports an error")
+		{
+			engine.Report(diag::err_unknown_directive) << "\\raven";
+			CHECK(text == "error: unknown directive `\\raven`\n");
+			CHECK(engine.getNumErrors() == 1);
+			CHECK(engine.getNumWarnings() == 0);
+		}
+
+		SECTION("reports a warning")
+		{
+			engine.Report(diag::warn_undocumented_decl) << decl->getCanonicalDecl();
+			CHECK(engine.getNumErrors() == 0);
+			CHECK(engine.getNumWarnings() == 1);
+
+			engine.Report(diag::note_undocumented_decl) << decl;
+			CHECK(text
+			      == "warning: function 'f' is not documented\n"
+			         "note: use `\\undocumented` to indicate that 'f' should not be documented\n");
+
+			CHECK(engine.getNumErrors() == 0);
+			CHECK(engine.getNumWarnings() == 1);
+		}
+	}
+} // namespace

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(llvm)

--- a/third_party/llvm/CMakeLists.txt
+++ b/third_party/llvm/CMakeLists.txt
@@ -1,0 +1,9 @@
+get_filename_component(LLVM_BIN "${CMAKE_CXX_COMPILER}" DIRECTORY)
+set(LLVM_TABLEGEN "${LLVM_BIN}/llvm-tblgen")
+set(CLANG_TABLEGEN "${LLVM_BIN}/clang-tblgen")
+set(CLANG_TABLEGEN_EXE "${CLANG_TABLEGEN}")
+find_package(LLVMTableGen REQUIRED)
+find_package(ClangTableGen REQUIRED)
+cmake_policy(SET CMP0116 OLD)
+
+add_subdirectory(diagnostics)

--- a/third_party/llvm/LICENSE.txt
+++ b/third_party/llvm/LICENSE.txt
@@ -1,0 +1,278 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2019 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.

--- a/third_party/llvm/diagnostics/CMakeLists.txt
+++ b/third_party/llvm/diagnostics/CMakeLists.txt
@@ -1,0 +1,18 @@
+include(TableGen)
+
+file(MAKE_DIRECTORY "${DIRECTORY}")
+macro(schreiber_diag_gen component)
+  clang_tablegen(
+    Diagnostic${component}Kinds.inc
+    -gen-clang-diags-defs
+    -clang-component=${component}
+    SOURCE Diagnostic.td
+    TARGET SchreiberDiagnostic${component}
+  )
+endmacro(schreiber_diag_gen)
+
+schreiber_diag_gen(Lex)
+
+get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)
+add_custom_target(schreiber-tablegen-targets DEPENDS "${CLANG_TABLEGEN_TARGETS}")
+set_target_properties(schreiber-tablegen-targets PROPERTIES FOLDER "Misc")

--- a/third_party/llvm/diagnostics/Diagnostic.td
+++ b/third_party/llvm/diagnostics/Diagnostic.td
@@ -1,0 +1,93 @@
+//===--- Diagnostic.td - C Language Family Diagnostic Handling ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the TableGen core definitions for the diagnostics
+//  and diagnostic control.
+//
+//===----------------------------------------------------------------------===//
+
+// See the LLVM Internals Manual, section The Diagnostics Subsystem for an overview.
+
+// Define the diagnostic severities.
+class Severity<string N> {
+  string Name = N;
+}
+def SEV_Ignored : Severity<"Ignored">;
+def SEV_Warning : Severity<"Warning">;
+def SEV_Error   : Severity<"Error">;
+def SEV_Fatal   : Severity<"Fatal">;
+
+// Define the diagnostic classes.
+class DiagClass;
+def CLASS_NOTE      : DiagClass;
+def CLASS_WARNING   : DiagClass;
+def CLASS_ERROR     : DiagClass;
+
+// Responses to a diagnostic in a SFINAE context.
+class SFINAEResponse;
+def SFINAE_SubstitutionFailure : SFINAEResponse;
+def SFINAE_Suppress            : SFINAEResponse;
+def SFINAE_Report              : SFINAEResponse;
+def SFINAE_AccessControl       : SFINAEResponse;
+
+// Textual substitutions which may be performed on the text of diagnostics
+class TextSubstitution<string Text> {
+  string Substitution = Text;
+  // TODO: These are only here to allow substitutions to be declared inline with
+  // diagnostics
+  string Component = "";
+  string CategoryName = "";
+  bit Deferrable = 0;
+}
+
+// DiagnosticGroups
+class DiagGroup<string Name, list<DiagGroup> subgroups = []> {
+  string GroupName = Name;
+  list<DiagGroup> SubGroups = subgroups;
+  string CategoryName = "";
+}
+class InGroup<DiagGroup G> { DiagGroup Group = G; }
+
+// All diagnostics emitted by the compiler are an indirect subclass of this.
+class Diagnostic<string summary, DiagClass DC, Severity defaultmapping> {
+  /// Component is specified by the file with a big let directive.
+  string         Component = ?;
+  string         Summary = summary;
+  DiagClass      Class = DC;
+  SFINAEResponse SFINAE = SFINAE_Suppress;
+  bit            AccessControl = 0;
+  bit            WarningNoWerror = 0;
+  bit            ShowInSystemHeader = 0;
+  bit            ShowInSystemMacro = 1;
+  bit            Deferrable = 0;
+  Severity       DefaultSeverity = defaultmapping;
+  DiagGroup      Group;
+  string         CategoryName = "";
+}
+
+class SFINAEFailure {
+  SFINAEResponse SFINAE = SFINAE_SubstitutionFailure;
+}
+class NoSFINAE {
+  SFINAEResponse SFINAE = SFINAE_Report;
+}
+
+class Error<string str>     : Diagnostic<str, CLASS_ERROR, SEV_Error>;
+
+// This is used for warnings about questionable code.
+class Warning<string str>   : Diagnostic<str, CLASS_WARNING, SEV_Warning>;
+
+// Notes can provide supplementary information on errors, warnings, and remarks.
+class Note<string str>      : Diagnostic<str, CLASS_NOTE, SEV_Ignored/*ignored*/>;
+
+class DefaultIgnore { Severity DefaultSeverity = SEV_Ignored; }
+class DefaultWarn   { Severity DefaultSeverity = SEV_Warning; }
+class DefaultError  { Severity DefaultSeverity = SEV_Error; }
+class DefaultFatal  { Severity DefaultSeverity = SEV_Fatal; }
+
+include "DiagnosticLexKinds.td"

--- a/third_party/llvm/diagnostics/DiagnosticLexKinds.td
+++ b/third_party/llvm/diagnostics/DiagnosticLexKinds.td
@@ -1,0 +1,12 @@
+let Component = "Lex", CategoryName = "Lexical issue" in {
+  // Errors (and correstponding notes)
+  def err_unknown_directive : Error<"unknown directive `%0`">;
+
+  // Warnings (and correstponding notes)
+  def warn_undocumented_decl : Warning<
+    "function %0 is not documented"
+  >;
+  def note_undocumented_decl : Note<
+    "use `\\undocumented` to indicate that %0 should not be documented"
+  >;
+}


### PR DESCRIPTION
TableGen is an effective way to organise and generate things such as diagnostic data and recognised symbols. It's a little bit Clangey at the moment, but that can probably be smoothed out over time, but this is to be expected since the structure and a lot of the code is directly imported from Clang.